### PR TITLE
Added PlatformVersion.java, and assessments with PlatformVersion

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
     </parent>
     <groupId>org.continuousassurance.swamp</groupId>
     <artifactId>java-api</artifactId>
-    <version>1.0-SNAPSHOT</version>
+    <version>1.1-SNAPSHOT</version>
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/src/main/java/org/continuousassurance/swamp/api/AssessmentRun.java
+++ b/src/main/java/org/continuousassurance/swamp/api/AssessmentRun.java
@@ -56,6 +56,10 @@ public class AssessmentRun extends SwampThing{
         this.platform = platform;
     }
 
+    public void setPlatformVersion(PlatformVersion platform_version) {
+        this.platform_version = platform_version;
+    }
+    
     public Tool getTool() {
         return tool;
     }
@@ -67,6 +71,7 @@ public class AssessmentRun extends SwampThing{
     Project project;
     PackageThing pkg;
     Platform platform;
+    PlatformVersion platform_version;
     Tool tool;
 
     @Override

--- a/src/main/java/org/continuousassurance/swamp/api/PlatformVersion.java
+++ b/src/main/java/org/continuousassurance/swamp/api/PlatformVersion.java
@@ -7,13 +7,44 @@ import org.continuousassurance.swamp.session.Session;
  * on 3/4/15 at  12:39 PM
  */
 public class PlatformVersion extends SwampThing {
-    public PlatformVersion(Session session) {
+    public static final String NAME_KEY ="full_name";
+    public static final String PLATFORM_UUID_KEY="platform_uuid";  
+    public static final String PLATFORM_VERSION_UUID_KEY ="platform_version_uuid";
+    public static final String VERSION_STRING ="version_string";
+
+    protected Platform platform;
+	
+    public Platform getPlatform() {
+		return platform;
+	}
+
+	public void setPlatform(Platform platform) {
+		this.platform = platform;
+	}
+
+	public PlatformVersion(Session session) {
         super(session);
     }
 
+	public String getFullName() {
+		return this.getConversionMap().getString(NAME_KEY);
+	}
+
+	public String getVersionString() {
+		return this.getConversionMap().getString(VERSION_STRING);
+	}
+
+	public String getPlatformVersionUuid() {
+		return this.getConversionMap().getString(PLATFORM_VERSION_UUID_KEY);
+	}
+
+	public String getName() {
+		return getFullName();
+	}
+	
     @Override
     public String getIDKey() {
-        return null;
+        return PLATFORM_VERSION_UUID_KEY;
     }
 
     @Override

--- a/src/main/java/org/continuousassurance/swamp/api/PlatformVersion.java
+++ b/src/main/java/org/continuousassurance/swamp/api/PlatformVersion.java
@@ -78,56 +78,80 @@ public class PlatformVersion extends SwampThing {
 	}
 	
 	public void standardize() {
-		
+
 		switch(getFullName()) {
 		case ("Android Android on Ubuntu 12.04 64-bit"):
 			standardize("Android Ubuntu", "12.04", Bits.BITS_64);
+		break;
 		case ("CentOS Linux 5 32-bit 5.11 32-bit"):
 			standardize("CentOS", "5.11", Bits.BITS_32);
+		break;
 		case ("CentOS Linux 5 64-bit 5.11 64-bit"):
 			standardize("CentOS", "5.11", Bits.BITS_64);
+		break;
 		case ("CentOS Linux 6 32-bit 6.7 32-bit"):
 			standardize("CentOS", "6.7", Bits.BITS_32);
+		break;
 		case ("CentOS Linux 6 64-bit 6.7 64-bit"):
 			standardize("CentOS", "6.7", Bits.BITS_64);
+		break;
 		case ("Debian Linux 7.11 64-bit"):
 			standardize("Debian", "7.11", Bits.BITS_64);
+		break;
 		case ("Debian Linux 8.6 64-bit"):
 			standardize("Debian", "8.6", Bits.BITS_64);
+		break;
 		case ("Fedora Linux 18 64-bit"):
 			standardize("Fedora", "18", Bits.BITS_64);
+		break;
 		case ("Fedora Linux 19 64-bit"):
 			standardize("Fedora", "19", Bits.BITS_64);
+		break;
 		case ("Fedora Linux 20 64-bit"):
 			standardize("Fedora", "20", Bits.BITS_64);
+		break;
 		case ("Fedora Linux 21 64-bit"):
 			standardize("Fedora", "21", Bits.BITS_64);
+		break;
 		case ("Fedora Linux 22 64-bit"):
 			standardize("Fedora", "22", Bits.BITS_64);
+		break;
 		case ("Fedora Linux 23 64-bit"):
 			standardize("Fedora", "23", Bits.BITS_64);
+		break;
 		case ("Fedora Linux 24 64-bit"):
 			standardize("Fedora", "24", Bits.BITS_64);
+		break;
 		case ("Red Hat Enterprise Linux 6 32-bit 6.7 32-bit"):
 			standardize("RHEL", "6.7", Bits.BITS_32);
+		break;
 		case ("Red Hat Enterprise Linux 6 64-bit 6.7 64-bit"):
 			standardize("RHEL", "6.7", Bits.BITS_64);
+		break;
 		case ("Scientific Linux 5 32-bit 5.11 32-bit"):
 			standardize("Scientific Linux", "5.11", Bits.BITS_32);
+		break;
 		case ("Scientific Linux 5 64-bit 5.11 64-bit"):
 			standardize("Scientific Linux", "5.11", Bits.BITS_64);
+		break;
 		case ("Scientific Linux 6 32-bit 6.7 32-bit"):
 			standardize("Scientific Linux", "6.7", Bits.BITS_32);
+		break;
 		case ("Scientific Linux 6 64-bit 6.7 64-bit"):
 			standardize("Scientific Linux", "6.7", Bits.BITS_64);
+		break;
 		case ("Ubuntu Linux 10.04 LTS 64-bit Lucid Lynx"):
 			standardize("Ubuntu", "10.04", Bits.BITS_64);
+		break;
 		case ("Ubuntu Linux 12.04 LTS 64-bit Precise Pangolin"):
 			standardize("Ubuntu", "12.04", Bits.BITS_64);
+		break;
 		case ("Ubuntu Linux 14.04 LTS 64-bit Trusty Tahr"):
 			standardize("Ubuntu", "14.04", Bits.BITS_64);
+		break;
 		case ("Ubuntu Linux 16.04 LTS 64-bit Xenial Xerus"):
 			standardize("Ubuntu", "16.04", Bits.BITS_64);
+		break;
 		default:
 			break;
 		}
@@ -146,7 +170,7 @@ public class PlatformVersion extends SwampThing {
 	}
 
 	public String getDisplayString() {
-		return String.format("%s %s %s", getName(), getVersion(), getBits());
+		return String.format("%s %s %s", getShortName(), getVersion(), getBits());
 	}
 	
 	public String toString() {

--- a/src/main/java/org/continuousassurance/swamp/api/PlatformVersion.java
+++ b/src/main/java/org/continuousassurance/swamp/api/PlatformVersion.java
@@ -7,24 +7,24 @@ import org.continuousassurance.swamp.session.Session;
  * on 3/4/15 at  12:39 PM
  */
 public class PlatformVersion extends SwampThing {
-    public static final String NAME_KEY ="full_name";
-    public static final String PLATFORM_UUID_KEY="platform_uuid";  
-    public static final String PLATFORM_VERSION_UUID_KEY ="platform_version_uuid";
-    public static final String VERSION_STRING ="version_string";
+    public static final String NAME_KEY = "full_name";
+    public static final String PLATFORM_UUID_KEY = "platform_uuid";  
+    public static final String PLATFORM_VERSION_UUID_KEY = "platform_version_uuid";
+    public static final String VERSION_STRING = "version_string";
 
     protected Platform platform;
-	
-    public Platform getPlatform() {
+
+	public PlatformVersion(Session session) {
+        super(session);
+    }
+
+	public Platform getPlatform() {
 		return platform;
 	}
 
 	public void setPlatform(Platform platform) {
 		this.platform = platform;
 	}
-
-	public PlatformVersion(Session session) {
-        super(session);
-    }
 
 	public String getFullName() {
 		return this.getConversionMap().getString(NAME_KEY);
@@ -51,4 +51,106 @@ public class PlatformVersion extends SwampThing {
     protected SwampThing getNewInstance() {
         return new PlatformVersion(getSession());
     }
+    
+	public enum Bits {
+		BITS_32,
+		BITS_64;
+		
+		public String toString () {
+			if (this == Bits.BITS_32){
+				return "32-bit";
+			}else {
+				return "64-bit";
+			}
+		}
+	}
+
+	
+	String shortName;
+	String version;
+	Bits bits;
+	
+	protected void standardize (String shortName, String version, Bits bits) {
+
+		this.shortName = shortName;
+		this.version = version;
+		this.bits = bits;
+	}
+	
+	public void standardize() {
+		
+		switch(getFullName()) {
+		case ("Android Android on Ubuntu 12.04 64-bit"):
+			standardize("Android Ubuntu", "12.04", Bits.BITS_64);
+		case ("CentOS Linux 5 32-bit 5.11 32-bit"):
+			standardize("CentOS", "5.11", Bits.BITS_32);
+		case ("CentOS Linux 5 64-bit 5.11 64-bit"):
+			standardize("CentOS", "5.11", Bits.BITS_64);
+		case ("CentOS Linux 6 32-bit 6.7 32-bit"):
+			standardize("CentOS", "6.7", Bits.BITS_32);
+		case ("CentOS Linux 6 64-bit 6.7 64-bit"):
+			standardize("CentOS", "6.7", Bits.BITS_64);
+		case ("Debian Linux 7.11 64-bit"):
+			standardize("Debian", "7.11", Bits.BITS_64);
+		case ("Debian Linux 8.6 64-bit"):
+			standardize("Debian", "8.6", Bits.BITS_64);
+		case ("Fedora Linux 18 64-bit"):
+			standardize("Fedora", "18", Bits.BITS_64);
+		case ("Fedora Linux 19 64-bit"):
+			standardize("Fedora", "19", Bits.BITS_64);
+		case ("Fedora Linux 20 64-bit"):
+			standardize("Fedora", "20", Bits.BITS_64);
+		case ("Fedora Linux 21 64-bit"):
+			standardize("Fedora", "21", Bits.BITS_64);
+		case ("Fedora Linux 22 64-bit"):
+			standardize("Fedora", "22", Bits.BITS_64);
+		case ("Fedora Linux 23 64-bit"):
+			standardize("Fedora", "23", Bits.BITS_64);
+		case ("Fedora Linux 24 64-bit"):
+			standardize("Fedora", "24", Bits.BITS_64);
+		case ("Red Hat Enterprise Linux 6 32-bit 6.7 32-bit"):
+			standardize("RHEL", "6.7", Bits.BITS_32);
+		case ("Red Hat Enterprise Linux 6 64-bit 6.7 64-bit"):
+			standardize("RHEL", "6.7", Bits.BITS_64);
+		case ("Scientific Linux 5 32-bit 5.11 32-bit"):
+			standardize("Scientific Linux", "5.11", Bits.BITS_32);
+		case ("Scientific Linux 5 64-bit 5.11 64-bit"):
+			standardize("Scientific Linux", "5.11", Bits.BITS_64);
+		case ("Scientific Linux 6 32-bit 6.7 32-bit"):
+			standardize("Scientific Linux", "6.7", Bits.BITS_32);
+		case ("Scientific Linux 6 64-bit 6.7 64-bit"):
+			standardize("Scientific Linux", "6.7", Bits.BITS_64);
+		case ("Ubuntu Linux 10.04 LTS 64-bit Lucid Lynx"):
+			standardize("Ubuntu", "10.04", Bits.BITS_64);
+		case ("Ubuntu Linux 12.04 LTS 64-bit Precise Pangolin"):
+			standardize("Ubuntu", "12.04", Bits.BITS_64);
+		case ("Ubuntu Linux 14.04 LTS 64-bit Trusty Tahr"):
+			standardize("Ubuntu", "14.04", Bits.BITS_64);
+		case ("Ubuntu Linux 16.04 LTS 64-bit Xenial Xerus"):
+			standardize("Ubuntu", "16.04", Bits.BITS_64);
+		default:
+			break;
+		}
+	}
+
+	public String getShortName() {
+		return shortName;
+	}
+
+	public String getVersion() {
+		return version;
+	}
+
+	public Bits getBits() {
+		return bits;
+	}
+
+	public String getDisplayString() {
+		return String.format("%s %s %s", getName(), getVersion(), getBits());
+	}
+	
+	public String toString() {
+		return getDisplayString();
+	}
+
 }

--- a/src/main/java/org/continuousassurance/swamp/api/ToolVersion.java
+++ b/src/main/java/org/continuousassurance/swamp/api/ToolVersion.java
@@ -1,5 +1,7 @@
 package org.continuousassurance.swamp.api;
 
+import java.util.Date;
+
 import org.continuousassurance.swamp.session.Session;
 
 /**
@@ -7,17 +9,36 @@ import org.continuousassurance.swamp.session.Session;
  * on 3/4/15 at  12:39 PM
  */
 public class ToolVersion extends SwampThing{
+    public static final String TOOL_VERSION_UUID_KEY = "tool_version_uuid";
+    public static final String TOOL_UUID_KEY = "tool_uuid";
+    public static final String VERSION_STRING_KEY = "version_string";
+    public static final String RELEASE_DATE_KEY = "release_date";
+    public static final String RETIRE_DATE_KEY = "retire_date";
+    public static final String NOTES_KEY = "notes";
+    public static final String TOOL_PATH_KEY = "tool_path";
+    public static final String TOOL_EXECUTABLE_KEY = "tool_executable";
+    public static final String TOOL_ARGUMENTS_KEY = "tool_arguments";
+    public static final String TOOL_DIRECTORY_KEY = "tool_directory";
+
     public ToolVersion(Session session) {
         super(session);
     }
 
     @Override
     public String getIDKey() {
-        return null;
+        return TOOL_VERSION_UUID_KEY;
     }
 
     @Override
     protected SwampThing getNewInstance() {
         return new ToolVersion(getSession());
+    }
+    
+    public String getVersion() {
+    	return getConversionMap().getString(VERSION_STRING_KEY);
+    }
+    
+    public Date getReleaseDate() {
+    	return getConversionMap().getDate(RELEASE_DATE_KEY);
     }
 }

--- a/src/main/java/org/continuousassurance/swamp/session/handlers/AssessmentRecordHandler.java
+++ b/src/main/java/org/continuousassurance/swamp/session/handlers/AssessmentRecordHandler.java
@@ -149,4 +149,10 @@ public class AssessmentRecordHandler<T extends AssessmentRecord> extends Abstrac
     public String getURL() {
         return createURL("assessment_runs");
     }
+    
+    public boolean deleteAssessmentRecord(AssessmentRecord assessmentRecord){
+    	String url = createURL("execution_records/" + assessmentRecord.getUUIDString());
+        MyResponse mr = getClient().delete(url);
+        return mr.hasJSON();
+    }
 }

--- a/src/main/java/org/continuousassurance/swamp/session/handlers/AssessmentRunHandler.java
+++ b/src/main/java/org/continuousassurance/swamp/session/handlers/AssessmentRunHandler.java
@@ -94,6 +94,24 @@ public class AssessmentRunHandler<T extends AssessmentRun> extends AbstractHandl
         return result;
     }
 
+    public AssessmentRun create(Project project, PackageVersion pkg_ver, PlatformVersion platform_version, Tool tool) {
+        String url = createURL("assessment_runs");
+        HashMap<String, Object> parameters = new HashMap<>();
+        parameters.put("project_uuid", project.getUUIDString());
+        parameters.put("package_version_uuid", pkg_ver.getUUIDString());
+        parameters.put(PackageHandler.PACKAGE_UUID_KEY, pkg_ver.getPackageThing().getUUIDString());
+        parameters.put(PLATFORM_UUID_KEY, platform_version.getUUIDString());
+        parameters.put(TOOL_UUID_KEY, tool.getUUIDString()); 
+        //parameters.put("tool_version_uuid", tool.getUUIDString());
+        MyResponse myResponse = getClient().rawPost(url, parameters);
+        AssessmentRun result = fromJSON(myResponse.json);
+        result.setProject(project);
+        result.setPkg(pkg_ver.getPackageThing());
+        result.setPlatform(platform_version.getPlatform());
+        result.setPlatformVersion(platform_version);
+        result.setTool(tool);
+        return result;
+    }
 
     public T get(Identifier identifier) {
         String url = createURL("assessment_runs/" + SWAMPIdentifiers.fromIdentifier(identifier));

--- a/src/main/java/org/continuousassurance/swamp/session/handlers/HandlerFactory.java
+++ b/src/main/java/org/continuousassurance/swamp/session/handlers/HandlerFactory.java
@@ -76,10 +76,21 @@ public class HandlerFactory {
         return platformHandler;
     }
 
+    public void setPlatformVersionHandler(PlatformVersionHandler<? extends PlatformVersion> platformVersionHandler) {
+        this.platformVersionHandler = platformVersionHandler;
+    }
+
+    public PlatformVersionHandler<? extends PlatformVersion> getPlatformVersionHandler() {
+        if(platformVersionHandler == null){
+            platformVersionHandler = new PlatformVersionHandler<>(getCSASession());
+        }
+        return platformVersionHandler;
+    }
+
     public void setPlatformHandler(PlatformHandler<? extends Platform> platformHandler) {
         this.platformHandler = platformHandler;
     }
-
+    
     public ProjectHandler<? extends Project> getProjectHandler() {
         if(projectHandler == null){
             projectHandler = new ProjectHandler<>(getRWSSession());
@@ -154,6 +165,7 @@ public class HandlerFactory {
 
     PackageVersionHandler<? extends PackageVersion> packageVersionHandler;
     PlatformHandler<? extends Platform> platformHandler;
+    PlatformVersionHandler<? extends PlatformVersion> platformVersionHandler;
     ProjectHandler<? extends Project> projectHandler;
     ToolHandler<? extends Tool> toolHandler;
     UserHandler<? extends User> userHandler;

--- a/src/main/java/org/continuousassurance/swamp/session/handlers/PackageHandler.java
+++ b/src/main/java/org/continuousassurance/swamp/session/handlers/PackageHandler.java
@@ -8,7 +8,9 @@ import org.continuousassurance.swamp.session.util.ConversionMapImpl;
 import net.sf.json.JSONObject;
 
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 /**
  * <p>Created by Jeff Gaynor<br>
@@ -130,7 +132,7 @@ public class PackageHandler<T extends PackageThing> extends AbstractHandler<T> {
         return createURL("packages");
     }
 
-
+    /*
     public List<String> getTypes() {
         String url = createURL("packages/types");
         MyResponse mr = getClient().rawGet(url, null);
@@ -138,6 +140,18 @@ public class PackageHandler<T extends PackageThing> extends AbstractHandler<T> {
         List<String> pkg_types = new ArrayList<String>();
         for (int i = 0; i < mr.jsonArray.size(); ++i){
         	pkg_types.add(mr.jsonArray.getJSONObject(i).getString("name"));
+        }
+        return pkg_types;
+    }*/
+    
+    public Map<String, Integer> getTypes() {
+        String url = createURL("packages/types");
+        MyResponse mr = getClient().rawGet(url, null);
+
+        Map<String, Integer> pkg_types = new HashMap<String, Integer>();
+        for (int i = 0; i < mr.jsonArray.size(); ++i){
+        	pkg_types.put(mr.jsonArray.getJSONObject(i).getString("name"),
+        			Integer.valueOf(mr.jsonArray.getJSONObject(i).getString("name")));
         }
         return pkg_types;
     }

--- a/src/main/java/org/continuousassurance/swamp/session/handlers/PackageHandler.java
+++ b/src/main/java/org/continuousassurance/swamp/session/handlers/PackageHandler.java
@@ -8,7 +8,9 @@ import org.continuousassurance.swamp.session.util.ConversionMapImpl;
 import net.sf.json.JSONObject;
 
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 /**
  * <p>Created by Jeff Gaynor<br>
@@ -130,7 +132,7 @@ public class PackageHandler<T extends PackageThing> extends AbstractHandler<T> {
         return createURL("packages");
     }
 
-
+    /*
     public List<String> getTypes() {
         String url = createURL("packages/types");
         MyResponse mr = getClient().rawGet(url, null);
@@ -140,6 +142,18 @@ public class PackageHandler<T extends PackageThing> extends AbstractHandler<T> {
         	pkg_types.add(mr.jsonArray.getJSONObject(i).getString("name"));
         }
         return pkg_types;
+    }*/
+
+    public Map<String, Integer> getTypes() {
+    	String url = createURL("packages/types");
+    	MyResponse mr = getClient().rawGet(url, null);
+
+    	Map<String, Integer> pkg_types = new HashMap<String, Integer>();
+    	for (int i = 0; i < mr.jsonArray.size(); ++i){
+    		pkg_types.put(mr.jsonArray.getJSONObject(i).getString("name"),
+    				Integer.valueOf(mr.jsonArray.getJSONObject(i).getInt("package_type_id")));
+    	}
+    	return pkg_types;
     }
 
     /*

--- a/src/main/java/org/continuousassurance/swamp/session/handlers/PlatformVersionHandler.java
+++ b/src/main/java/org/continuousassurance/swamp/session/handlers/PlatformVersionHandler.java
@@ -1,0 +1,70 @@
+package org.continuousassurance.swamp.session.handlers;
+
+import org.continuousassurance.swamp.api.Platform;
+import org.continuousassurance.swamp.api.PlatformVersion;
+import org.continuousassurance.swamp.session.MyResponse;
+import org.continuousassurance.swamp.session.Session;
+import org.continuousassurance.swamp.session.util.ConversionMapImpl;
+
+import edu.uiuc.ncsa.security.core.exceptions.NotImplementedException;
+import net.sf.json.JSONObject;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * <p>Created by Jeff Gaynor<br>
+ * on 12/10/14 at  2:18 PM
+ */
+public class PlatformVersionHandler<T extends PlatformVersion> extends AbstractHandler<T> {
+    public PlatformVersionHandler(Session session) {
+        super(session);
+    }
+
+    @Override
+    public List<T> getAll() {
+        throw new NotImplementedException();
+    }
+
+    public List<T> getAll(Platform platform) {
+        String url = createURL("platforms/" + platform.getIdentifierString() + "/versions");
+              MyResponse mr = getClient().rawGet(url, null);
+              ArrayList<T> platform_versions = new ArrayList<>();
+              for (int i = 0; i < mr.jsonArray.size(); i++) {
+                  JSONObject json = mr.jsonArray.getJSONObject(i);
+                  T platform_version = fromJSON(json);
+                  platform_version.setPlatform(platform);
+                  platform_versions.add(platform_version);
+              }
+              return platform_versions;
+    }
+
+    protected T fromJSON(JSONObject json) {
+        T platform_version = (T) new PlatformVersion(getSession());
+        
+        String[] sAttrib = {T.NAME_KEY, T.VERSION_STRING};
+        String[] uAttrib = {T.PLATFORM_VERSION_UUID_KEY, T.PLATFORM_UUID_KEY};
+        
+        ConversionMapImpl map = new ConversionMapImpl();
+        setAttributes(map, sAttrib, json, DATA_TYPE_STRING);
+        setAttributes(map, uAttrib, json, DATA_TYPE_IDENTIFIER);
+        
+        
+        platform_version.setConversionMap(map);
+        return platform_version;
+    }
+
+    public PlatformVersion find(String name){
+        for(PlatformVersion p: getAll()){
+            if(p.getName().equals(name)){
+                return p;
+            }
+        }
+        return null;
+    }
+
+    @Override
+    public String getURL() {
+        return createURL("platforms");
+    }
+}

--- a/src/main/java/org/continuousassurance/swamp/session/handlers/PlatformVersionHandler.java
+++ b/src/main/java/org/continuousassurance/swamp/session/handlers/PlatformVersionHandler.java
@@ -34,6 +34,7 @@ public class PlatformVersionHandler<T extends PlatformVersion> extends AbstractH
                   JSONObject json = mr.jsonArray.getJSONObject(i);
                   T platform_version = fromJSON(json);
                   platform_version.setPlatform(platform);
+                  platform_version.standardize();
                   platform_versions.add(platform_version);
               }
               return platform_versions;

--- a/src/main/java/org/continuousassurance/swamp/session/handlers/ToolVersionHandler.java
+++ b/src/main/java/org/continuousassurance/swamp/session/handlers/ToolVersionHandler.java
@@ -1,5 +1,6 @@
 package org.continuousassurance.swamp.session.handlers;
 
+import org.continuousassurance.swamp.api.Project;
 import org.continuousassurance.swamp.api.Tool;
 import edu.uiuc.ncsa.security.core.exceptions.NotImplementedException;
 import org.continuousassurance.swamp.api.ToolVersion;
@@ -10,6 +11,8 @@ import net.sf.json.JSONObject;
 
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.HashMap;
+import java.util.List;
 
 /**
  * <p>Created by Jeff Gaynor<br>
@@ -19,45 +22,23 @@ public class ToolVersionHandler<T extends ToolVersion> extends AbstractHandler<T
     public ToolVersionHandler(Session session) {
         super(session);
     }
-    public static final String TOOL_VERSION_UUID_KEY = "tool_version_uuid";
-    public static final String TOOL_UUID_KEY = "tool_uuid";
-    public static final String VERSION_STRING_KEY = "version_string";
-    public static final String RELEASE_DATE_KEY = "release_date";
-    public static final String RETIRE_DATE_KEY = "retire_date";
-    public static final String NOTES_KEY = "notes";
-    public static final String TOOL_PATH_KEY = "tool_path";
-    public static final String TOOL_EXECUTABLE_KEY = "tool_executable";
-    public static final String TOOL_ARGUMENTS_KEY = "tool_arguments";
-    public static final String TOOL_DIRECTORY_KEY = "tool_directory";
 
 
     @Override
     protected T fromJSON(JSONObject json) {
-        T tv = (T) new ToolVersion(getSession());
-            ConversionMapImpl map = new ConversionMapImpl();
-            String[] sAttrib = {NOTES_KEY,VERSION_STRING_KEY,TOOL_PATH_KEY,TOOL_EXECUTABLE_KEY,TOOL_ARGUMENTS_KEY,TOOL_DIRECTORY_KEY};
-            String[] uAttrib = {TOOL_UUID_KEY,TOOL_VERSION_UUID_KEY};
-            String[] dAttrib = {RELEASE_DATE_KEY,RETIRE_DATE_KEY};
-            setAttributes(map, sAttrib, json, DATA_TYPE_STRING);
-            setAttributes(map, dAttrib, json, DATA_TYPE_DATE);
-            setAttributes(map, uAttrib, json, DATA_TYPE_IDENTIFIER);
-//            setAttributes(map, bAttrib, json, DATA_TYPE_BOOLEAN);/*
-  /*
-        		$toolVersion->tool_version_uuid = Input::get('tool_version_uuid');
-		$toolVersion->tool_uuid = Input::get('tool_uuid');
-		$toolVersion->version_string = Input::get('version_string');
+    	T tv = (T) new ToolVersion(getSession());
+    	ConversionMapImpl map = new ConversionMapImpl();
+    	String[] sAttrib = {T.NOTES_KEY, T.VERSION_STRING_KEY, T.TOOL_PATH_KEY,
+    			T.TOOL_EXECUTABLE_KEY, T.TOOL_ARGUMENTS_KEY, T.TOOL_DIRECTORY_KEY};
+    	String[] uAttrib = {T.TOOL_UUID_KEY, T.TOOL_VERSION_UUID_KEY};
+    	String[] dAttrib = {T.RELEASE_DATE_KEY, T.RETIRE_DATE_KEY};
+    	
+    	setAttributes(map, sAttrib, json, DATA_TYPE_STRING);
+    	setAttributes(map, dAttrib, json, DATA_TYPE_DATE);
+    	setAttributes(map, uAttrib, json, DATA_TYPE_IDENTIFIER);
 
-		$toolVersion->release_date = Input::get('release_date');
-		$toolVersion->retire_date = Input::get('retire_date');
-		$toolVersion->notes = Input::get('notes');
-
-		$toolVersion->tool_path = Input::get('tool_path');
-		$toolVersion->tool_executable = Input::get('tool_executable');
-		$toolVersion->tool_arguments = Input::get('tool_arguments');
-		$toolVersion->tool_directory = Input::get('tool_directory');
-         */
-        tv.setConversionMap(map);
-        return tv;
+    	tv.setConversionMap(map);
+    	return tv;
     }
 
     @Override
@@ -76,9 +57,31 @@ public class ToolVersionHandler<T extends ToolVersion> extends AbstractHandler<T
      * @param tool
      * @return
      */
-    public Collection<T> getAll(Tool tool) {
+    public List<T> getAll(Tool tool) {
         String x = createURL("tools/" + tool.getIdentifierString() + "/versions");
         MyResponse mr = getClient().rawGet(x, null);
+        ArrayList<T> tools = new ArrayList<>();
+        if (mr.jsonArray == null) {
+            return tools;
+        }
+        for (int i = 0; i < mr.jsonArray.size(); i++) {
+            JSONObject json = mr.jsonArray.getJSONObject(i);
+            tools.add(fromJSON(json));
+        }
+        return tools;
+    }
+    
+    /**
+     * Return all versions of the given tool.
+     *
+     * @param tool
+     * @return
+     */
+    public List<T> getAll(Tool tool, String pkg_type) {
+        String x = createURL("tools/" + tool.getIdentifierString() + "/versions");
+        HashMap<String, Object> map = new HashMap<String, Object>();
+        map.put("package-type", pkg_type);
+        MyResponse mr = getClient().rawGet(x, map);
         ArrayList<T> tools = new ArrayList<>();
         if (mr.jsonArray == null) {
             return tools;

--- a/src/main/java/org/continuousassurance/swamp/session/util/SWAMPConfigurationLoader.java
+++ b/src/main/java/org/continuousassurance/swamp/session/util/SWAMPConfigurationLoader.java
@@ -143,6 +143,29 @@ public class SWAMPConfigurationLoader<T extends SWAMPServiceEnvironment> extends
         }
         return webServerURL;
     }
+    
+    public static String getWebServiceURL(String serverURL, SSLConfiguration sslConfiguration) {
+        if(!serverURL.endsWith("/")){
+            serverURL = serverURL + "/";
+        }
+        
+        //sslConfiguration.setUseDefaultJavaTrustStore(true);
+        SWAMPHttpClient client = new SWAMPHttpClient(serverURL,sslConfiguration);
+        MyResponse raw = client.rawGet(serverURL + "config/config.json");
+        String webServerURL = null;
+        if(raw.hasJSON()){
+            if(raw.json.containsKey("servers")){
+                JSONObject servers = raw.json.getJSONObject("servers");
+                if(servers.containsKey("web")){
+                    webServerURL = servers.getString("web");
+                }
+            }
+        }
+        if(webServerURL == null){
+            return null;
+        }
+        return webServerURL;
+    }
 
 
     /**


### PR DESCRIPTION
1. Added support PlatformVersion.java and PlatformVersionHandler.java
2. Added Assessments run calls to use PlatformVersion
3. PackageHandler.java:getTypes() should return a hash map not a list
4. Added AssessmentRecordHandler.java:deleteAssessmentRecord method
5. Added overloaded method SWAMPConfigurationLoader.java:getWebServiceURL(String serverURL, SSLConfiguration sslConfiguration)
6. Changed the version in pom.xml to 1.1-SNAPSHOT